### PR TITLE
Update CI workflow for basic build

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,3 +19,5 @@ jobs:
         sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
     - name: Build
       run: make
+    - name: Test
+      run: make test


### PR DESCRIPTION
## Summary
- update CI workflow to only build and run tests

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6864b93fd4548328b2b104b145e6d283