### PR TITLE
Fix quadtree particle lifetime

### DIFF
--- a/src/particle.c
+++ b/src/particle.c
@@ -47,17 +47,26 @@ void initParticles(Particles* particles, int numParticles) {
 void computeForces(Particles* particles, int numParticles, float G) {
     QuadNode* root = createNode(-1.0f, -1.0f, 1.0f, 1.0f);
 
+    Particle* tempParticles = (Particle*)malloc(numParticles * sizeof(Particle));
+
     for (int i = 0; i < numParticles; ++i) {
-        Particle p = {particles->x[i], particles->y[i], particles->vx[i], particles->vy[i], particles->ax[i], particles->ay[i], particles->mass[i]};
-        insertParticle(root, &p);
+        tempParticles[i].x = particles->x[i];
+        tempParticles[i].y = particles->y[i];
+        tempParticles[i].vx = particles->vx[i];
+        tempParticles[i].vy = particles->vy[i];
+        tempParticles[i].ax = particles->ax[i];
+        tempParticles[i].ay = particles->ay[i];
+        tempParticles[i].mass = particles->mass[i];
+        insertParticle(root, &tempParticles[i]);
     }
 
     for (int i = 0; i < numParticles; ++i) {
-        Particle p = {particles->x[i], particles->y[i], particles->vx[i], particles->vy[i], particles->ax[i], particles->ay[i], particles->mass[i]};
-        computeForce(root, &p, 0.5f, G);
-        particles->ax[i] = p.ax;
-        particles->ay[i] = p.ay;
+        computeForce(root, &tempParticles[i], 0.5f, G);
+        particles->ax[i] = tempParticles[i].ax;
+        particles->ay[i] = tempParticles[i].ay;
     }
+
+    free(tempParticles);
 
     freeQuadtree(root);
 }

--- a/src/quadtree.c
+++ b/src/quadtree.c
@@ -70,7 +70,8 @@ void insertParticle(QuadNode* node, Particle* p) {
 }
 
 void computeForce(QuadNode* node, Particle* p, float theta, float G) {
-    if (node == NULL || node->particle == p) return;
+    if (node == NULL) return;
+    if (node->particle != NULL && node->particle == p) return;
 
     float dx = node->centerX - p->x;
     float dy = node->centerY - p->y;


### PR DESCRIPTION
## Summary
- allocate stable Particle structs when building the quadtree
- guard against null/duplicate particles in Barnes–Hut force calculation

## Testing
- `make` *(fails: cannot find `-lmpi`)*

------
https://chatgpt.com/codex/tasks/task_e_6864b94e50e483289b30bd336d1bc64e