### PR TITLE
Add scroll-based attraction control

### DIFF
--- a/include/controls.h
+++ b/include/controls.h
@@ -8,6 +8,9 @@
 extern float centerX;
 extern float centerY;
 
+// Current attraction strength (modifiable via scroll input)
+extern float attractionStrength;
+
 // Function to initialize controls
 void initControls(GLFWwindow* window);
 

--- a/src/controls.c
+++ b/src/controls.c
@@ -8,6 +8,7 @@
 
 // Define centerX and centerY here
 float centerX = 0.0f, centerY = 0.0f;
+float attractionStrength = ATTRACTION_STRENGTH;
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -36,6 +37,16 @@ void mouseButtonCallback(GLFWwindow* window, int button, int action, int mods) {
     }
 }
 
+void handleScroll(GLFWwindow* window, double xoffset, double yoffset) {
+    (void)window; // unused
+    (void)xoffset;
+    attractionStrength += (float)yoffset * 0.01f;
+    if (attractionStrength < 0.0f) {
+        attractionStrength = 0.0f;
+    }
+    printf("Attraction Strength: %f\n", attractionStrength);
+}
+
 void handleInput(GLFWwindow* window, Particles* particles, int numParticles) {
     if (glfwGetKey(window, GLFW_KEY_R) == GLFW_PRESS) {
         resetSimulation(particles, numParticles);  // Ensure this function is defined
@@ -45,6 +56,7 @@ void handleInput(GLFWwindow* window, Particles* particles, int numParticles) {
 void initControls(GLFWwindow* window) {
     glfwSetCursorPosCallback(window, cursor_position_callback);
     glfwSetMouseButtonCallback(window, mouseButtonCallback); // Set mouse button callback
+    glfwSetScrollCallback(window, handleScroll);
 }
 
 // Ensure the function signature matches the declaration

--- a/src/main.c
+++ b/src/main.c
@@ -48,7 +48,7 @@ int main(int argc, char* argv[]) {
         float dt = 0.016f;  // Simulate a fixed timestep (approx. 60 FPS)
 
         handleInput(window, &particles, MAX_PARTICLES);  // Handle input
-        applyAttraction(&particles, MAX_PARTICLES, centerX, centerY, ATTRACTION_STRENGTH); // Apply attraction
+        applyAttraction(&particles, MAX_PARTICLES, centerX, centerY, attractionStrength); // Apply attraction
         updateParticlesAndForces(&particles, MAX_PARTICLES, dt);
 
         drawParticles(&particles, MAX_PARTICLES);  // Draw particles


### PR DESCRIPTION
## Summary
- track current attraction strength in `controls`
- adjust attraction strength via mouse scroll events
- use the variable in `main`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6864b94ce08c8328b68979e2114fb13f