### PR TITLE
Add Makefile test target with quadtree test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,18 @@ src/shader_utils.o: src/shader_utils.c include/shader_utils.h
 src/controls.o: src/controls.c include/controls.h include/particle.h
 	$(CC) $(CFLAGS) -c -o $@ $<
 
+TEST_OBJ = tests/test_quadtree.o src/quadtree.o
+TEST_BIN = tests/test_quadtree
+TEST_LDFLAGS = -lm
+
+$(TEST_BIN): $(TEST_OBJ)
+	$(CC) -o $@ $(TEST_OBJ) $(TEST_LDFLAGS)
+
+tests/test_quadtree.o: tests/test_quadtree.c include/quadtree.h include/particle_struct.h
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
 clean:
-	rm -f src/*.o gravity_simulation
+	rm -f src/*.o $(OBJ) gravity_simulation $(TEST_BIN) tests/*.o

--- a/tests/test_quadtree.c
+++ b/tests/test_quadtree.c
@@ -1,0 +1,21 @@
+#include "quadtree.h"
+#include <stdio.h>
+
+int main() {
+    QuadNode* root = createNode(0.0f, 0.0f, 1.0f, 1.0f);
+    if (!root) {
+        fprintf(stderr, "Failed to create root node\n");
+        return 1;
+    }
+    if (root->minX != 0.0f || root->minY != 0.0f || root->maxX != 1.0f || root->maxY != 1.0f) {
+        fprintf(stderr, "Node bounds incorrect\n");
+        return 1;
+    }
+    if (root->centerX != 0.5f || root->centerY != 0.5f) {
+        fprintf(stderr, "Node center incorrect\n");
+        return 1;
+    }
+    freeQuadtree(root);
+    printf("test_quadtree passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple unit test for `createNode` in `quadtree`
- extend `Makefile` with a `test` target and supporting rules
- clean up extra build artifacts in the `clean` rule

## Testing
- `make test`