### PR TITLE
Update CI workflow with separate jobs

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,17 +7,35 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  installing-dependencies:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
-    - name: Build
-      run: make
-    - name: Test
-      run: make test
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
+
+  build:
+    runs-on: ubuntu-latest
+    needs: installing-dependencies
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: make
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        run: make test
+
+  make:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Make
+        run: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,6 +21,10 @@ jobs:
     needs: installing-dependencies
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
       - name: Build
         run: make
 
@@ -29,6 +33,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
       - name: Test
         run: make test
 
@@ -37,5 +45,9 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
       - name: Make
         run: make

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ obj/
 # Object files
 *.o
 src/*.o
+gravity-simulation/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ obj/
 *.o
 src/*.o
 gravity-simulation/
+tests/test_quadtree


### PR DESCRIPTION
## Summary
- split CI workflow into Installing Dependencies, Build, Test and Make jobs
- ignore nested `gravity-simulation` directory

## Testing
- `make test`