### PR TITLE
Improve cache usage in CI

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -13,14 +13,6 @@ jobs:
     container: ghcr.io/gravity-sim/deps:latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache build artifacts
-        uses: actions/cache@v3
-        with:
-          path: |
-            src/*.o
-            tests/*.o
-          key: ${{ runner.os }}-build-${{ hashFiles('**/*.c') }}
-          restore-keys: ${{ runner.os }}-build-
       - name: Setup complete
         run: echo "Dependencies are pre-installed in the container"
 
@@ -32,15 +24,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore build cache
-        uses: actions/cache@v3
+        id: build-cache
+        uses: actions/cache/restore@v3
         with:
           path: |
             src/*.o
             tests/*.o
           key: ${{ runner.os }}-build-${{ hashFiles('**/*.c') }}
-          restore-keys: ${{ runner.os }}-build-
       - name: Build
         run: make
+      - name: Save build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            src/*.o
+            tests/*.o
+          key: ${{ steps.build-cache.outputs.cache-primary-key }}
 
   test:
     name: Test
@@ -50,13 +50,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             src/*.o
             tests/*.o
           key: ${{ runner.os }}-build-${{ hashFiles('**/*.c') }}
-          restore-keys: ${{ runner.os }}-build-
       - name: Test
         run: make test
 
@@ -77,12 +76,11 @@ jobs:
       run: make test
       - uses: actions/checkout@v4
       - name: Restore build cache
-        uses: actions/cache@v3
+        uses: actions/cache/restore@v3
         with:
           path: |
             src/*.o
             tests/*.o
           key: ${{ runner.os }}-build-${{ hashFiles('**/*.c') }}
-          restore-keys: ${{ runner.os }}-build-
       - name: Make
         run: make

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
+        sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev 
     - name: Build
       run: make
     - name: Test


### PR DESCRIPTION
## Summary
- move build cache restore to the build job
- persist object file cache after building
- update downstream jobs to restore the new cache

## Testing
- `make test`
