### PR TITLE
Add make deps target for prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,8 @@ test: $(TEST_BIN)
 
 clean:
 	rm -f src/*.o $(OBJ) gravity_simulation $(TEST_BIN) tests/*.o
+
+.PHONY: deps
+deps:
+	sudo apt-get update && \
+	sudo apt-get install -y build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev

--- a/README.md
+++ b/README.md
@@ -38,11 +38,19 @@ To build and run the simulation, ensure you have the necessary dependencies inst
 - GLEW
 - GLFW
 
+- OpenMPI
+
 On Ubuntu, you can install these with:
 
 ```bash
 sudo apt-get update
-sudo apt-get install build-essential libgl1-mesa-dev libglew-dev libglfw3-dev
+sudo apt-get install build-essential libgl1-mesa-dev libglew-dev libglfw3-dev libopenmpi-dev
+```
+
+Alternatively, you can install all dependencies via Make:
+
+```bash
+make deps
 ```
 
 ## Build


### PR DESCRIPTION
## Summary
- add a `deps` target in Makefile for installing packages
- document dependencies installation via `make deps`

## Testing
- `make clean`
- `make`
- `make test`